### PR TITLE
Merged PR 91: Remove the required owner attribute

### DIFF
--- a/QBDiscordAssistant/QBDiscordAssistant/DiscordBot/DiscordNet/AdminBotCommands.cs
+++ b/QBDiscordAssistant/QBDiscordAssistant/DiscordBot/DiscordNet/AdminBotCommands.cs
@@ -5,7 +5,6 @@ using Discord.Commands;
 
 namespace QBDiscordAssistant.DiscordBot.DiscordNet
 {
-    [RequireOwner]
     [RequireUserPermission(GuildPermission.Administrator)]
     [SuppressMessage(
         "Design",

--- a/QBDiscordAssistant/QBDiscordAssistant/QBDiscordAssistant.csproj
+++ b/QBDiscordAssistant/QBDiscordAssistant/QBDiscordAssistant.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PackageId>Quiz Bowl Discord Tournament Assistant</PackageId>
-    <Version>0.1.0.0</Version>
+    <Version>0.1.0.1</Version>
     <Authors>Alejandro Lopez-Lago</Authors>
     <Product>Quiz Bowl Discord Tournament Assistant</Product>
     <Copyright>2020 (c) Alejandro Lopez-Lago</Copyright>


### PR DESCRIPTION
Remove the required owner attribute for admin commands, since that will only let the bot owner run them.